### PR TITLE
Bump to 0.5.1 zkverify version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**0.5.1**
+
+* This release includes version **0.5.1** of the [zkVerify](https://github.com/HorizenLabs/zkVerify) project.
+
 **0.5.0**
 
 * This release includes version **0.5.0** (exactly **0.5.0-0.5.0**, **node_version-runtime_version**) of the [zkVerify](https://github.com/HorizenLabs/zkVerify) project.

--- a/env/.env.boot-node.testnet.template
+++ b/env/.env.boot-node.testnet.template
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=zkverify-boot-testnet
 
 # Node miscellaneous
-NODE_VERSION="0.5.0"
+NODE_VERSION="0.5.1"
 NODE_NAME="boot-node"
 NODE_NET_P2P_PORT=30333
 NODE_NET_P2P_PORT_WS=30334

--- a/env/.env.rpc-node.testnet.template
+++ b/env/.env.rpc-node.testnet.template
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=zkverify-rpc-testnet
 
 # Node miscellaneous
-NODE_VERSION="0.5.0"
+NODE_VERSION="0.5.1"
 NODE_NAME="rpc-node"
 NODE_NET_P2P_PORT=30555
 NODE_NET_RPC_PORT=9944

--- a/env/.env.validator-node.testnet.template
+++ b/env/.env.validator-node.testnet.template
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=zkverify-validator-testnet
 
 # Node miscellaneous
-NODE_VERSION="0.5.0"
+NODE_VERSION="0.5.1"
 NODE_NAME="validator-node"
 NODE_NET_P2P_PORT=30666
 


### PR DESCRIPTION
zkVerify GitHub tag 0.5.1-0.5.0 (up to 0.5.0-Infinity) zkVerify Docker tag 0.5.1

## Description
Bumping to 0.5.1

## Jira Ticket
[ZKV-522](https://horizenlabs.atlassian.net/browse/ZKV-552)

## Changes
 - Bumping versions

## Breaking Changes
None

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified

## Additional information
None